### PR TITLE
chore: Fix java-spotless-lint working directory

### DIFF
--- a/.github/workflows/java-spotless-lint.yml
+++ b/.github/workflows/java-spotless-lint.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6.1.0
       - name: Run Spotless check
-        run: ./gradlew :${{ inputs.gradle-module }}:spotlessCheck
+        run: ./gradlew spotlessCheck
+        working-directory: ${{ inputs.gradle-module }}
         env:
           GITHUB_USERNAME: ${{ secrets.github-username }}
           PERSONAL_ACCESS_TOKEN_GITHUB: ${{ secrets.personal-access-token-github }}

--- a/.github/workflows/java-spotless-lint.yml
+++ b/.github/workflows/java-spotless-lint.yml
@@ -27,6 +27,9 @@ on:
 jobs:
   java-spotless-lint:
     runs-on: ${{ inputs.runner-labels }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.gradle-module }}
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Set up JDK
@@ -41,7 +44,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v6.1.0
       - name: Run Spotless check
         run: ./gradlew spotlessCheck
-        working-directory: ${{ inputs.gradle-module }}
         env:
           GITHUB_USERNAME: ${{ secrets.github-username }}
           PERSONAL_ACCESS_TOKEN_GITHUB: ${{ secrets.personal-access-token-github }}


### PR DESCRIPTION
The spotlessCheck job should run in the specific service directory.

Changed from using gradle module prefix to running with working-directory parameter.